### PR TITLE
implement rules in the reverse proxy director function

### DIFF
--- a/main.go
+++ b/main.go
@@ -23,8 +23,6 @@ type Options struct {
 	Target         string
 	ConfigFilePath string
 	LogLevel       string
-	Remote         *url.URL
-	Config         *config.Main
 }
 
 func (o *Options) Validate() error {
@@ -36,38 +34,17 @@ func (o *Options) Validate() error {
 		return errors.New("please set '-config' to the path of your config.yaml file")
 	}
 
-	remote, err := url.Parse(o.Target)
-	if err != nil {
-		return errors.New(fmt.Sprintf("unable to parse target address '%s'", o.Target))
-	}
-	o.Remote = remote
-
-	o.Config = &config.Main{}
-	data, err := ioutil.ReadFile(o.ConfigFilePath)
-	if err != nil {
-		return errors.New(fmt.Sprintf("could not read config file '%s'", o.ConfigFilePath))
-	}
-
-	err = yaml.Unmarshal(data, o.Config)
-	if err != nil {
-		return errors.New("could not parse config file, please ensure it is valid YAML")
-	}
-
-	err = config.Validate(o.Config)
-	if err != nil {
-		return errors.New("failed to validate config")
-	}
-
 	return nil
 }
 
 type Router struct {
 	Log  zerolog.Logger
 	Opts *Options
+	Config *config.Main
 }
 
 func main() {
-	opts := Options{}
+	opts := &Options{}
 	flag.StringVar(&opts.Host, "host", "127.0.0.1", "Host to listen on")
 	flag.StringVar(&opts.Port, "port", "80", "Port to listen on")
 	flag.StringVar(&opts.Target, "target", "", "Address of your openHAB instance, e.g. 'http://openhab:8080'")
@@ -94,29 +71,67 @@ func main() {
 		log.Fatal().Err(err).Msg("invalid options, exiting")
 	}
 
-	log.Debug().Interface("config", opts).Msg("processed configuration")
-
-	router := Router{
-		Log:  logger,
-		Opts: &opts,
+	conf := &config.Main{}
+	data, err := ioutil.ReadFile(opts.ConfigFilePath)
+	if err != nil {
+		log.Fatal().Msgf("could not read config file '%s'", opts.ConfigFilePath)
 	}
 
-	proxy := httputil.NewSingleHostReverseProxy(opts.Remote)
-	mux := http.NewServeMux()
+	if err := yaml.Unmarshal(data, conf); err != nil {
+		log.Fatal().Msg("could not parse config file, please ensure it is valid YAML")
+	}
 
-	mux.HandleFunc("/liveness", router.LivenessProbeHandler)
-	mux.HandleFunc("/readiness", func(w http.ResponseWriter, r *http.Request) {
-		router.ReadinessProbeHandler(w, r, router.Opts.Remote)
-	})
+	if err := config.Validate(conf); err != nil {
+		log.Fatal().Msg("failed to validate config")
+	}
 
-	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		mainHandler(w, r, router.Opts.Config, proxy)
-	})
+	log.Debug().Interface("config", opts).Msg("processed configuration")
+
+	router := &Router{
+		Log:  logger,
+		Opts: opts,
+		Config: conf,
+	}
+
+	proxy := router.MakeProxy()
+	mux := router.MakeMux(proxy)
 
 	log.Info().Str("host", router.Opts.Host).Str("port", router.Opts.Port).Msg("serving")
 	if err := http.ListenAndServe(fmt.Sprintf("%s:%s", router.Opts.Host, router.Opts.Port), mux); err != nil {
 		log.Fatal().Err(err).Msg("failed serving")
 	}
+}
+
+func (r *Router) MakeProxy() *httputil.ReverseProxy {
+	remote, err := url.Parse(r.Opts.Target)
+	if err != nil {
+		log.Fatal().Msg("failed to parse given target")
+	}
+	proxy := httputil.NewSingleHostReverseProxy(remote)
+	defaultDirector := proxy.Director
+	proxy.Director = func(req *http.Request) {
+		defaultDirector(req)
+		ruleDirector(req, r.Config)
+	}
+	return proxy
+}
+
+func (r *Router) MakeMux(proxy *httputil.ReverseProxy) *http.ServeMux {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/liveness", r.LivenessProbeHandler)
+
+	remote, err := url.Parse(r.Opts.Target)
+	if err != nil {
+		log.Fatal().Msg("failed to parse given target")
+	}
+	mux.HandleFunc("/readiness", func(w http.ResponseWriter, req *http.Request) {
+		r.ReadinessProbeHandler(w, req, remote)
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, req *http.Request) {
+		mainHandler(w, req, r.Config, proxy)
+	})
+
+	return mux
 }
 
 // LivenessProbeHandler responds with HTTP 200
@@ -137,102 +152,101 @@ func (r *Router) ReadinessProbeHandler(w http.ResponseWriter, req *http.Request,
 	w.WriteHeader(http.StatusOK)
 }
 
-func mainHandler(w http.ResponseWriter, r *http.Request, conf *config.Main, proxy *httputil.ReverseProxy) {
-	user := r.Header.Get("X-Forwarded-Username")
-	if user == "" && conf.Passthrough == false {
-		failRequest(w, r, "The header 'X-Forwarded-Username' is either not set or empty")
+func ruleDirector(req *http.Request, conf *config.Main) {
+	user := req.Header.Get("X-Forwarded-Username")
+	logger := log.With().Str("user", user).Logger()
+
+	if conf.Passthrough {
+		logger.Debug().Str("uri", req.URL.RequestURI()).Msg("passthrough request served")
 		return
 	}
 
-	logger := log.With().Str("user", user).Logger()
+	// Every user is forced to their entrypoint
+	if req.URL.RequestURI() == "/" || req.URL.RequestURI() == "" {
+		logger.Debug().Msgf("redirecting to default entry-point %s", conf.Users[user].Entrypoint)
+		req.URL.Path = conf.Users[user].Entrypoint
+	}
 
-	if conf.Passthrough == false {
-		_, ok := conf.Users[user]
-		if ok == false {
-			logger.Debug().Msgf("User '%s' not found in config; tried to access '%s'", user, r.URL.RequestURI())
-			w.WriteHeader(403)
+	// Check if the requested path is disallowed; if yes go to entrypoint
+	for pathPart, pathConfig := range conf.Users[user].Paths {
+		if strings.Contains(req.URL.RequestURI(), pathPart) {
+			if pathConfig.Allowed == false {
+				logger.Debug().Msgf("redirecting to default entrypoint %s - denying access to %s", conf.Users[user].Entrypoint, req.URL.RequestURI())
+				req.URL.Path = conf.Users[user].Entrypoint
+			}
+		}
+	}
+
+	// Handle basicui access
+	if strings.HasPrefix(req.URL.RequestURI(), "/basicui/app") {
+		queryString := req.URL.Query()
+		sitemap := queryString.Get("sitemap")
+		if sitemap == "" {
+			queryString.Set("sitemap", conf.Users[user].Sitemaps.Default)
+			req.URL.RawQuery = queryString.Encode()
+			logger.Debug().Msgf("redirecting to default sitemap %s - no sitemap was given on the request", conf.Users[user].Sitemaps.Default)
 			return
 		}
-
-		logger.Debug().Str("uri", r.URL.RequestURI()).Msg("")
-
-		// Every user is forced to their entrypoint
-		if r.URL.RequestURI() == "/" || r.URL.RequestURI() == "" {
-			logger.Debug().Msgf("redirecting to default entry-point %s", conf.Users[user].Entrypoint)
-			http.Redirect(w, r, conf.Users[user].Entrypoint, http.StatusPermanentRedirect)
-			return
-		}
-
-		// Check if the requested path is disallowed; if yes go to entrypoint
-		for pathPart, pathConfig := range conf.Users[user].Paths {
-			if strings.Contains(r.URL.RequestURI(), pathPart) {
-				if pathConfig.Allowed == false {
-					logger.Debug().Msgf("redirecting to default entrypoint %s - denying access to %s", conf.Users[user].Entrypoint, r.URL.RequestURI())
-					http.Redirect(w, r, conf.Users[user].Entrypoint, http.StatusPermanentRedirect)
+		if sitemap != "" && sitemap != conf.Users[user].Sitemaps.Default {
+			if len(conf.Users[user].Sitemaps.Allowed) == 1 && conf.Users[user].Sitemaps.Allowed[0] == "*" {
+				return
+			}
+			for _, allowedSitemap := range conf.Users[user].Sitemaps.Allowed {
+				if sitemap == allowedSitemap {
 					return
 				}
 			}
+			queryString.Set("sitemap", conf.Users[user].Sitemaps.Default)
+			req.URL.RawQuery = queryString.Encode()
+			logger.Debug().Msgf("redirecting to default sitemap %s - denying access to requested sitemap %s", conf.Users[user].Sitemaps.Default, sitemap)
+			return
 		}
-
-		// Handle basicui access
-		if strings.HasPrefix(r.URL.RequestURI(), "/basicui/app") {
-			queryString := r.URL.Query()
-			sitemap := queryString.Get("sitemap")
-			if sitemap == "" {
-				queryString.Set("sitemap", conf.Users[user].Sitemaps.Default)
-				r.URL.RawQuery = queryString.Encode()
-				logger.Debug().Msgf("redirecting to default sitemap %s - no sitemap was given on the request", conf.Users[user].Sitemaps.Default)
-				http.Redirect(w, r, r.URL.String(), http.StatusPermanentRedirect)
-				return
-			}
-			if sitemap != "" && sitemap != conf.Users[user].Sitemaps.Default {
-				if len(conf.Users[user].Sitemaps.Allowed) == 1 && conf.Users[user].Sitemaps.Allowed[0] == "*" {
-					goto serve
-				}
-				for _, allowedSitemap := range conf.Users[user].Sitemaps.Allowed {
-					if sitemap == allowedSitemap {
-						goto serve
-					}
-				}
-				queryString.Set("sitemap", conf.Users[user].Sitemaps.Default)
-				r.URL.RawQuery = queryString.Encode()
-				logger.Debug().Msgf("redirecting to default sitemap %s - denying access to requested sitemap %s", conf.Users[user].Sitemaps.Default, sitemap)
-				http.Redirect(w, r, r.URL.String(), http.StatusPermanentRedirect)
-				return
-			}
-		}
-
-		// Handle rest access
-		if strings.HasPrefix(r.URL.RequestURI(), "/rest") {
-			if strings.HasPrefix(r.URL.RequestURI(), "/rest/sitemaps/events") {
-				goto serve
-			}
-			if strings.HasPrefix(r.URL.RequestURI(), "/rest/sitemaps/_default") {
-				http.Redirect(w, r, "/rest/sitemaps/"+conf.Users[user].Sitemaps.Default, http.StatusPermanentRedirect)
-				return
-			}
-			if strings.HasPrefix(r.URL.RequestURI(), "/rest/sitemaps/") {
-				if len(conf.Users[user].Sitemaps.Allowed) == 1 && conf.Users[user].Sitemaps.Allowed[0] == "*" {
-					goto serve
-				}
-				for _, allowedSitemap := range conf.Users[user].Sitemaps.Allowed {
-					if strings.Contains(r.URL.RequestURI(), allowedSitemap) {
-						goto serve
-					}
-				}
-				parts := strings.Split(r.URL.RequestURI(), "/")
-				defaultSitemapURL := strings.Replace(r.URL.RequestURI(), parts[3], conf.Users[user].Sitemaps.Default, -1)
-				logger.Debug().Msgf("redirecting to default sitemap %s - denying access to requested resource %s via REST API call", conf.Users[user].Sitemaps.Default, r.URL.RequestURI())
-				http.Redirect(w, r, defaultSitemapURL, http.StatusPermanentRedirect)
-				return
-			}
-		}
-	} else {
-		logger.Debug().Str("uri", r.URL.RequestURI()).Msg("passthrough request served")
 	}
 
-serve:
-	proxy.ServeHTTP(w, r)
+	// Handle rest access
+	if strings.HasPrefix(req.URL.RequestURI(), "/rest") {
+		if strings.HasPrefix(req.URL.RequestURI(), "/rest/sitemaps/events") {
+			return
+		}
+		if strings.HasPrefix(req.URL.RequestURI(), "/rest/sitemaps/_default") {
+			req.URL.Path = "/rest/sitemaps/"+conf.Users[user].Sitemaps.Default
+			return
+		}
+		if strings.HasPrefix(req.URL.RequestURI(), "/rest/sitemaps/") {
+			if len(conf.Users[user].Sitemaps.Allowed) == 1 && conf.Users[user].Sitemaps.Allowed[0] == "*" {
+				return
+			}
+			for _, allowedSitemap := range conf.Users[user].Sitemaps.Allowed {
+				if strings.Contains(req.URL.RequestURI(), allowedSitemap) {
+					return
+				}
+			}
+			parts := strings.Split(req.URL.RequestURI(), "/")
+			defaultSitemapURL := strings.Replace(req.URL.RequestURI(), parts[3], conf.Users[user].Sitemaps.Default, -1)
+			logger.Debug().Msgf("redirecting to default sitemap %s - denying access to requested resource %s via REST API call", conf.Users[user].Sitemaps.Default, req.URL.RequestURI())
+			req.URL.Path = defaultSitemapURL
+			return
+		}
+	}
+}
+
+func mainHandler(w http.ResponseWriter, req *http.Request, conf *config.Main, proxy *httputil.ReverseProxy) {
+	if conf.Passthrough == false {
+		user := req.Header.Get("X-Forwarded-Username")
+		if user == "" && conf.Passthrough == false {
+			failRequest(w, req, "the header 'X-Forwarded-Username' is either not set or empty")
+			return
+		}
+
+		_, ok := conf.Users[user]
+		if ok == false {
+			log.Debug().Str("user", user).Str("uri", req.URL.RequestURI()).Msg("user not found")
+			w.WriteHeader(403)
+			return
+		}
+	}
+
+	proxy.ServeHTTP(w, req)
 }
 
 func failRequest(w http.ResponseWriter, r *http.Request, message string) {

--- a/testing/test.sh
+++ b/testing/test.sh
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-trap "echo ### TESTS FAILED ###" ERR
-
 [[ ! -f "wait-for-it" ]] && \
   echo "downloading wait-for-it" && \
   wget -O wait-for-it https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh && \
@@ -75,3 +73,5 @@ curl -sL --fail --show-error -u demo:demo "http://localhost/basicui/app?sitemap=
 
 # cleanup
 rm openhab-auth-router
+
+echo "SUCCESS"


### PR DESCRIPTION
This changeset removes the code smell of using `goto` syntax in the main part of the application. Instead, all the rule evaluation has been refactored into the director function of the reverse proxy, which can be used to manipulate requests before they are processed by the proxy.

I am also hoping to see an improvement of the linear memory consumption. Local testing with pprof showed an improvement, however a load test in prod will reveal a better understanding.